### PR TITLE
Update to Sonerezh 1.2 and add docker-compose compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore .env file (like mariadb.env and database-info.env) to avoid accidental commit of personnal data
+*.env

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sonerezh with Docker / sebcworks version
+# Sonerezh with Docker
 
 This is the Git repository of the official Docker image for [Sonerezh](https://www.sonerezh.bzh). See the Hub page for more informations.
 
@@ -9,9 +9,9 @@ This is the Git repository of the official Docker image for [Sonerezh](https://w
 Simply clone this repository and use `docker build`:
 
 ```sh
-$> git clone --master https://github.com/sebcworks/sonerezh-docker
+$> git clone --master https://github.com/Sonerezh/docker
 $> cd docker/nginx
-$> docker build --tag sebcworks/sonerezh .
+$> docker build --tag sonerezh .
 ```
 
 ## How to use this image
@@ -40,7 +40,7 @@ $> docker run --name sonerezh-app --link sonerezh-db:sonerezh-db \
                                   --env MYSQL_PASSWORD=changemetoo \
                                   --env MYSQL_DATABASE=sonerezh \
                                   --detach --publish 8080:80 \
-                                  sebcworks/sonerezh
+                                  sonerezh/sonerezh
 ```
 
 Your Sonerezh instance is available at http://127.0.0.1:8080 :) Make sure Sonerezh have read access to `/path/to/music` and read/write access to `/path/to/thumbnails`.
@@ -70,9 +70,9 @@ Next, you'll have to:
 Your folder should looks like this:
 
 ```ls
--rw-r--r-- 1 root root  80 Aug 18 15:27 database-info.env
+-rw-r----- 1 root root  80 Aug 18 15:27 database-info.env
 -rw-r--r-- 1 root root 729 Aug 18 15:29 docker-compose.yml
--rw-r--r-- 1 root root  57 Aug 18 15:27 mariadb.env
+-rw-r----- 1 root root  57 Aug 18 15:27 mariadb.env
 ```
 
 Then, all you can launch the containers:
@@ -86,4 +86,4 @@ $> docker-compose up -d
 ## Contributing
 
 You are invited to contribute new features, fixes, or update, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
-Before you start to code, we recommend discussing your plans through a [GitHub issue on the original repository](https://github.com/Sonerezh/sonerezh/issues), especially for more ambitious contributions.
+Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/Sonerezh/sonerezh/issues), especially for more ambitious contributions.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,89 @@
-# Sonerezh with Docker
+# Sonerezh with Docker / sebcworks version
 
 This is the Git repository of the official Docker image for [Sonerezh](https://www.sonerezh.bzh). See the Hub page for more informations.
 
 **WARNING**: the Docker image for Sonerezh is still under development. Some functionnality are broken like email notifications for example.
 
-# How to build this image
+## How to build this image
 
 Simply clone this repository and use `docker build`:
 
 ```sh
-$ git clone --master https://github.com/Sonerezh/docker.git
-$ cd docker/nginx
-$ docker build --tag sonerezh .
+$> git clone --master https://github.com/sebcworks/sonerezh-docker
+$> cd docker/nginx
+$> docker build --tag sebcworks/sonerezh .
 ```
-# How to use this image
 
-## Manually
+## How to use this image
+
+### Manually
 
 You can configure your Sonerezh instance manually. First you will need to run `mysql` or `mariadb` container:
 
 ```sh
-$ docker run --name sonerezh-db --env MYSQL_ROOT_PASSWORD=changeme \
-								--env MYSQL_USER=sonerezh \
-								--env MYSQL_PASSWORD=changemetoo \
-								--env MYSQL_DATABASE=sonerezh \
-								--volume /path/to/mysql/data:/var/lib/mysql \
-								--detach mariadb
+$> docker run --name sonerezh-db --env MYSQL_ROOT_PASSWORD=changeme \
+                                 --env MYSQL_USER=sonerezh \
+                                 --env MYSQL_PASSWORD=changemetoo \
+                                 --env MYSQL_DATABASE=sonerezh \
+                                 --volume /path/to/mysql/data:/var/lib/mysql \
+                                 --detach \
+                                 mariadb
 ```
 
 And then run Sonerezh container:
 
 ```sh
-$ docker run --name sonerezh-app --link sonerezh-db:sonerezh-db \
-								 --volume /path/to/music:/music \
-								 --volume /path/to/thumbnails:/thumbnails \
-								 --detach --publish 8080:80 \
-								 sonerezh/sonerezh:latest
+$> docker run --name sonerezh-app --link sonerezh-db:sonerezh-db \
+                                  --volume /path/to/music:/music:ro \
+                                  --volume /path/to/thumbnails:/thumbnails \
+                                  --env MYSQL_USER=sonerezh \
+                                  --env MYSQL_PASSWORD=changemetoo \
+                                  --env MYSQL_DATABASE=sonerezh \
+                                  --detach --publish 8080:80 \
+                                  sebcworks/sonerezh
 ```
 
 Your Sonerezh instance is available at http://127.0.0.1:8080 :) Make sure Sonerezh have read access to `/path/to/music` and read/write access to `/path/to/thumbnails`.
 
-## Via docker-compose
+### Via docker-compose
 
-Coming soon
+See example [docker-compose file](nginx/docker-compose.yml)
 
-# Contributing
+Next, you'll have to:
+
+* create mariadb.env file (see [example](nginx/mariadb.env.example))
+* create database-info.env file (see [example](nginx/database-info.env.example))
+* update the docker-compose.yml file to set the link to your music in the volume definition (you may do the same for thumbnails)
+
+```yaml
+    volumes:
+      - /path/to/your/music:/music:ro
+```
+
+* *optionnaly* update the exposed port
+
+```yaml
+    ports:
+      - 8080:80
+```
+
+Your folder should looks like this:
+
+```ls
+-rw-r--r-- 1 root root  80 Aug 18 15:27 database-info.env
+-rw-r--r-- 1 root root 729 Aug 18 15:29 docker-compose.yml
+-rw-r--r-- 1 root root  57 Aug 18 15:27 mariadb.env
+```
+
+Then, all you can launch the containers:
+
+```sh
+$> pwd
+/path/to/your/folder/sonerezh
+$> docker-compose up -d
+```
+
+## Contributing
+
 You are invited to contribute new features, fixes, or update, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
-Before you start to code, we recommend discussing your plans through a [GitHub issue](https://github.com/Sonerezh/sonerezh/issues), especially for more ambitious contributions.
+Before you start to code, we recommend discussing your plans through a [GitHub issue on the original repository](https://github.com/Sonerezh/sonerezh/issues), especially for more ambitious contributions.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 	supervisor
 
 # Install Sonerezh
-RUN git clone --branch 1.1.1 --depth 1 https://github.com/Sonerezh/sonerezh.git /usr/share/nginx/sonerezh && \
+RUN git clone --branch 1.2.0 --depth 1 https://github.com/Sonerezh/sonerezh.git /usr/share/nginx/sonerezh && \
 	chown -R www-data: /usr/share/nginx/sonerezh && \
 	chmod 775 -R /usr/share/nginx/sonerezh
 
@@ -22,17 +22,12 @@ RUN mkdir /music && \
 	ln -s /usr/share/nginx/sonerezh/app/webroot/img/thumbnails /thumbnails && \
 	chown www-data: /music
 
-VOLUME /music
-VOLUME /thumbnails
-
 # Copy image configuration
 RUN rm -f /etc/nginx/sites-enabled/default
 COPY database.php /usr/share/nginx/sonerezh/app/Config/database.php
 COPY default /etc/nginx/sites-enabled/default
 COPY supervisord.conf etc/supervisor/conf.d/supervisord.conf
 COPY docker-entrypoint.sh /entrypoint.sh
-
-EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/supervisord"]

--- a/nginx/database-info.env.example
+++ b/nginx/database-info.env.example
@@ -1,0 +1,3 @@
+MYSQL_USER=sonerezh
+MYSQL_PASSWORD=xxxxx
+MYSQL_DATABASE=sonerezh

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - database-info.env
     restart: always
   app:
-    image: sebcworks/sonerezh:latest
+    image: sonerezh/sonerezh:latest
     depends_on:
       - sonerezh-db
     volumes:

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - database-info.env
     restart: always
   app:
-    image: sonerezh/sonerezh:latest
+    image: sebcworks/sonerezh:latest
     depends_on:
       - sonerezh-db
     volumes:

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  sonerezh-db:
+    image: mariadb
+    volumes:
+      - sonerezh-db-data:/var/lib/mysql
+    env_file: 
+      - mariadb.env
+      - database-info.env
+    restart: always
+  app:
+    image: sonerezh/sonerezh:latest
+    depends_on:
+      - sonerezh-db
+    volumes:
+      - /path/to/your/music:/music:ro
+      - sonerezh-thumnails:/thumbnails
+    links:
+      - sonerezh-db:sonerezh-db
+    ports:
+      - 8080:80
+    env_file:
+      - database-info.env
+    restart: always
+volumes:
+  sonerezh-db-data:
+    driver: local
+  sonerezh-thumnails:
+    driver: local

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 set -e
 
-if [ -z "$SONEREZH_DB_PORT_3306_TCP_ADDR" ]; then
-	echo >&2 'error: missing required SONEREZH_DB_ENV_MYSQL_PASSWORD environment variable'
-	echo >&2 '	Did you forget to --link some-mysql-container:mysql?'
+#
+# - Take host from link name: MUST BE "sonerezh-db"
+# - Take database name from our own environment variable "MYSQL_DATABASE" (default to sonerezh)
+# - Same for database user "MYSQL_USER" (default to sonerezh) 
+# - Same for database password "MYSQL_PASSWORD" (but no default!)
+#
+
+if [ -z "$MYSQL_DATABASE" ]; then
+	echo >&2 'error: missing required MYSQL_DATABASE environment variable'
 	exit 1
 fi
 
-if [ -z "$SONEREZH_DB_ENV_MYSQL_DATABASE" ]; then
-	echo >&2 'error: missing required SONEREZH_DB_ENV_MYSQL_PASSWORD environment variable'
-	echo >&2 '	Did you forget to --link some-mysql-container:mysql?'
-	exit 1
-fi
-
-if [ -z "$SONEREZH_DB_ENV_MYSQL_USER" ]; then
+if [ -z "$MYSQL_USER" ]; then
 	echo >&2 'error: missing required MYSQL_USER environment variable'
-	echo >&2 '	Did you forget to --link some-mysql-container:mysql?'
 	exit 1
 fi
 
-if [ -z "$SONEREZH_DB_ENV_MYSQL_PASSWORD" ]; then
+if [ -z "$MYSQL_PASSWORD" ]; then
 	echo >&2 'error: missing required MYSQL_PASSWORD environment variable'
-	echo >&2 '	Did you forget to --link some-mysql-container:mysql?'
 	exit 1
 fi
 
-sed -i "s/SONEREZH_DB_PORT_3306_TCP_ADDR/${SONEREZH_DB_PORT_3306_TCP_ADDR}/" /usr/share/nginx/sonerezh/app/Config/database.php
-sed -i "s/SONEREZH_DB_ENV_MYSQL_DATABASE/${SONEREZH_DB_ENV_MYSQL_DATABASE}/" /usr/share/nginx/sonerezh/app/Config/database.php
-sed -i "s/SONEREZH_DB_ENV_MYSQL_USER/${SONEREZH_DB_ENV_MYSQL_USER}/" /usr/share/nginx/sonerezh/app/Config/database.php
-sed -i "s/SONEREZH_DB_ENV_MYSQL_PASSWORD/${SONEREZH_DB_ENV_MYSQL_PASSWORD}/" /usr/share/nginx/sonerezh/app/Config/database.php
+sed -i "s/SONEREZH_DB_PORT_3306_TCP_ADDR/sonerezh-db/" /usr/share/nginx/sonerezh/app/Config/database.php
+sed -i "s/SONEREZH_DB_ENV_MYSQL_DATABASE/${MYSQL_DATABASE}/" /usr/share/nginx/sonerezh/app/Config/database.php
+sed -i "s/SONEREZH_DB_ENV_MYSQL_USER/${MYSQL_USER}/" /usr/share/nginx/sonerezh/app/Config/database.php
+sed -i "s/SONEREZH_DB_ENV_MYSQL_PASSWORD/${MYSQL_PASSWORD}/" /usr/share/nginx/sonerezh/app/Config/database.php
 sed -i "s/define('DOCKER', false)/define('DOCKER', true)/" /usr/share/nginx/sonerezh/app/Config/bootstrap.php
 
 exec "$@"

--- a/nginx/mariadb.env.example
+++ b/nginx/mariadb.env.example
@@ -1,0 +1,1 @@
+MYSQL_ROOT_PASSWORD=xxxxx


### PR DESCRIPTION
Update Dockerfile to use Sonerezh 1.2.0 and change the way the entrypoint is made to bring back docker and docker-compose compatibility. Add a docker-compose.yml file as well as examples of "env_file".
README was updated to reflect these changes (as well as some minor format changes).