### PR TITLE
Support Sonerezh 1.2.4

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM php:7.2.11-fpm-stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -7,16 +7,23 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 	git \
 	libav-tools \
 	nginx \
-	php5-fpm \
-	php5-gd \
-	php5-mysql \
+	unzip \
 	supervisor
 
+# Install Composer
+COPY docker-install-composer /usr/local/bin
+RUN docker-install-composer
+
+# Install pdo_mysql (script from the php image)
+RUN docker-php-ext-install pdo_mysql
+
+
 # Install Sonerezh
-RUN git clone --branch 1.1.1 --depth 1 https://github.com/Sonerezh/sonerezh.git /usr/share/nginx/sonerezh && \
+RUN git clone --branch 1.2.4 --depth 1 https://github.com/Sonerezh/sonerezh.git /usr/share/nginx/sonerezh && \
 	chown -R www-data: /usr/share/nginx/sonerezh && \
 	chmod 775 -R /usr/share/nginx/sonerezh
 
+RUN cd /usr/share/nginx/sonerezh && composer install
 # Prepare volume
 RUN mkdir /music && \
 	ln -s /usr/share/nginx/sonerezh/app/webroot/img/thumbnails /thumbnails && \
@@ -29,10 +36,9 @@ VOLUME /thumbnails
 RUN rm -f /etc/nginx/sites-enabled/default
 COPY database.php /usr/share/nginx/sonerezh/app/Config/database.php
 COPY default /etc/nginx/sites-enabled/default
-COPY supervisord.conf etc/supervisor/conf.d/supervisord.conf
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY docker-entrypoint.sh /entrypoint.sh
 
 EXPOSE 80
-
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/nginx/default
+++ b/nginx/default
@@ -22,7 +22,7 @@ server {
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_index index.php;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass 127.0.0.1:9000;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include /etc/nginx/fastcgi_params;
     }

--- a/nginx/docker-install-composer
+++ b/nginx/docker-install-composer
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(curl -s https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/nginx/supervisord.conf
+++ b/nginx/supervisord.conf
@@ -4,5 +4,5 @@ nodaemon=true
 [program:nginx]
 command=nginx -g "daemon off;"
 
-[program:php5fpm]
-command=php5-fpm --fpm-config /etc/php5/fpm/php-fpm.conf -F
+[program:php-fpm]
+command=php-fpm


### PR DESCRIPTION
As I wanted to run 1.2.4 in docker as I used to, I updated and made your Dockerfile somehow adequate... it can probably be done better using docker compose in the main repo, but this works as the outdated "latest" image used to.

It is available on docker hub as gilou/sonerezh:1.2.4-7 